### PR TITLE
[feat] 부의금 송금 카카오페이 연동 기능

### DIFF
--- a/src/main/java/com/smwu_itple/backend/SmwuItpleApplication.java
+++ b/src/main/java/com/smwu_itple/backend/SmwuItpleApplication.java
@@ -1,9 +1,13 @@
 package com.smwu_itple.backend;
 
+import com.smwu_itple.backend.dto.KakaoPayProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SmwuItpleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/smwu_itple/backend/controller/KakaoPayController.java
+++ b/src/main/java/com/smwu_itple/backend/controller/KakaoPayController.java
@@ -1,0 +1,56 @@
+package com.smwu_itple.backend.controller;
+
+import com.smwu_itple.backend.dto.request.KakaoApproveRequest;
+import com.smwu_itple.backend.dto.request.KakaoReadyRequest;
+import com.smwu_itple.backend.dto.response.KakaoApproveResponse;
+import com.smwu_itple.backend.dto.response.KakaoReadyResponse;
+import com.smwu_itple.backend.infra.api.ApiResponse;
+import com.smwu_itple.backend.infra.api.FailureStatus;
+import com.smwu_itple.backend.infra.api.SuccessStatus;
+import com.smwu_itple.backend.service.KakaoPayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/payment")
+@RequiredArgsConstructor
+public class KakaoPayController {
+    private final KakaoPayService kakaoPayService;
+
+    /** 결제 요청 */
+    @PostMapping(value = "/ready", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse> readyToKakaoPay(@RequestBody KakaoReadyRequest request) {
+        try {
+            KakaoReadyResponse response = kakaoPayService.kakaoPayReady(request);
+            return ApiResponse.onSuccess(response, SuccessStatus._PAYMENT_READY_SUCCESS);
+        } catch (Exception e) {
+            return ApiResponse.onFailure(null, FailureStatus._BAD_REQUEST, e.getMessage());
+        }
+    }
+
+
+    /** 결제 성공 처리 */
+    @PostMapping("/success")
+    public ResponseEntity<ApiResponse> afterPayRequest(@RequestBody KakaoApproveRequest request) {
+        try {
+            KakaoApproveResponse response = kakaoPayService.kakaoPayApprove(request);
+            return ApiResponse.onSuccess(response, SuccessStatus._PAYMENT_APPROVE_SUCCESS);
+        } catch (Exception e) {
+            return ApiResponse.onFailure(null, FailureStatus._BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    /** 결제 취소 */
+    @GetMapping("/cancel")
+    public ResponseEntity<ApiResponse> cancel() {
+        return ApiResponse.onFailure(null, FailureStatus._BAD_REQUEST, "결제가 취소되었습니다.");
+    }
+
+    /** 결제 실패 */
+    @GetMapping("/fail")
+    public ResponseEntity<ApiResponse> fail() {
+        return ApiResponse.onFailure(null, FailureStatus._BAD_REQUEST, "결제가 실패하였습니다.");
+    }
+}

--- a/src/main/java/com/smwu_itple/backend/dto/KakaoPayProperties.java
+++ b/src/main/java/com/smwu_itple/backend/dto/KakaoPayProperties.java
@@ -1,0 +1,15 @@
+package com.smwu_itple.backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakaopay")
+public class KakaoPayProperties {
+    private String secretKey;
+    private String cid;
+}

--- a/src/main/java/com/smwu_itple/backend/dto/request/KakaoApproveRequest.java
+++ b/src/main/java/com/smwu_itple/backend/dto/request/KakaoApproveRequest.java
@@ -1,0 +1,12 @@
+package com.smwu_itple.backend.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoApproveRequest {
+    private String orderId;
+    private String userId;
+    private String pgToken;
+}

--- a/src/main/java/com/smwu_itple/backend/dto/request/KakaoReadyRequest.java
+++ b/src/main/java/com/smwu_itple/backend/dto/request/KakaoReadyRequest.java
@@ -1,0 +1,15 @@
+package com.smwu_itple.backend.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoReadyRequest {
+    private String orderId;
+    private String userId;
+    private String itemName;
+    private int totalAmount;
+    private int vatAmount;
+}
+

--- a/src/main/java/com/smwu_itple/backend/dto/response/Amount.java
+++ b/src/main/java/com/smwu_itple/backend/dto/response/Amount.java
@@ -1,0 +1,13 @@
+package com.smwu_itple.backend.dto.response;
+
+import lombok.Data;
+
+@Data
+public class Amount {
+    private int total;
+    private int tax_free;
+    private int tax;
+    private int point;
+    private int discount;
+    private int green_deposit;
+}

--- a/src/main/java/com/smwu_itple/backend/dto/response/KakaoApproveResponse.java
+++ b/src/main/java/com/smwu_itple/backend/dto/response/KakaoApproveResponse.java
@@ -1,0 +1,21 @@
+package com.smwu_itple.backend.dto.response;
+
+import lombok.Data;
+
+@Data
+public class KakaoApproveResponse {
+    private String aid;
+    private String tid;
+    private String cid;
+    private String sid;
+    private String partner_order_id;
+    private String partner_user_id;
+    private String payment_method_type;
+    private Amount amount;
+    private String item_name;
+    private String item_code;
+    private int quantity;
+    private String created_at;
+    private String approved_at;
+    private String payload;
+}

--- a/src/main/java/com/smwu_itple/backend/dto/response/KakaoReadyResponse.java
+++ b/src/main/java/com/smwu_itple/backend/dto/response/KakaoReadyResponse.java
@@ -1,0 +1,14 @@
+package com.smwu_itple.backend.dto.response;
+
+import lombok.Data;
+
+@Data
+public class KakaoReadyResponse {
+    private String tid;
+    private String next_redirect_app_url;
+    private String next_redirect_mobile_url;
+    private String next_redirect_pc_url;
+    private String android_app_scheme;
+    private String ios_app_scheme;
+    private String created_at;
+}

--- a/src/main/java/com/smwu_itple/backend/infra/api/SuccessStatus.java
+++ b/src/main/java/com/smwu_itple/backend/infra/api/SuccessStatus.java
@@ -16,7 +16,9 @@ public enum SuccessStatus {
     _POST_MESSAGE_CREATE_SUCCESS("조문 메시지 전송 성공"),
     _POST_PAY_CREATE_SUCCESS("부의금 전송 성공"),
     _GET_MESSAGELIST_SUCCESS("조문 메시지 리스트 조회 성공"),
-    _GET_PAYLIST_SUCCESS("부의금 리스트 조회 성공");
+    _GET_PAYLIST_SUCCESS("부의금 리스트 조회 성공"),
+    _PAYMENT_READY_SUCCESS("결제 요청 성공"),
+    _PAYMENT_APPROVE_SUCCESS("결제 처리 성공");
 
     private final String message;
 

--- a/src/main/java/com/smwu_itple/backend/service/KakaoPayService.java
+++ b/src/main/java/com/smwu_itple/backend/service/KakaoPayService.java
@@ -1,0 +1,75 @@
+package com.smwu_itple.backend.service;
+
+import com.smwu_itple.backend.dto.KakaoPayProperties;
+import com.smwu_itple.backend.dto.request.KakaoApproveRequest;
+import com.smwu_itple.backend.dto.request.KakaoReadyRequest;
+import com.smwu_itple.backend.dto.response.KakaoApproveResponse;
+import com.smwu_itple.backend.dto.response.KakaoReadyResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class KakaoPayService {
+    private final KakaoPayProperties payProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private KakaoReadyResponse kakaoReady;
+
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "SECRET_KEY " + payProperties.getSecretKey());
+        headers.set("Content-Type", "application/json");
+        return headers;
+    }
+
+    /** 결제 준비 요청 */
+    public KakaoReadyResponse kakaoPayReady(KakaoReadyRequest request) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("cid", payProperties.getCid());
+        parameters.put("partner_order_id", request.getOrderId()); // 프론트에서 받은 주문 ID
+        parameters.put("partner_user_id", request.getUserId()); // 프론트에서 받은 사용자 ID
+        parameters.put("item_name", request.getItemName()); // 상품명
+        parameters.put("quantity", 1); // 수량
+        parameters.put("total_amount", request.getTotalAmount()); // 총 금액
+        parameters.put("vat_amount", request.getVatAmount()); // 부가세
+        parameters.put("tax_free_amount", 0); // 면세 금액
+        parameters.put("approval_url", "http://localhost:8081/api/payment/success"); // 결제 성공 URL
+        parameters.put("fail_url", "http://localhost:8081/api/payment/fail"); // 결제 실패 URL
+        parameters.put("cancel_url", "http://localhost:8081/api/payment/cancel"); // 결제 취소 URL
+
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
+        kakaoReady = restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/ready",
+                requestEntity, KakaoReadyResponse.class);
+
+        return kakaoReady;
+    }
+
+    /** 결제 승인 요청 */
+    public KakaoApproveResponse kakaoPayApprove(KakaoApproveRequest request) {
+        if (kakaoReady == null) {
+            throw new IllegalStateException("카카오페이 결제 준비가 완료되지 않았습니다.");
+        }
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("cid", payProperties.getCid());
+        parameters.put("tid", kakaoReady.getTid()); // 결제 준비 시 받은 TID 사용
+        parameters.put("partner_order_id", request.getOrderId()); // 프론트에서 받은 주문 ID
+        parameters.put("partner_user_id", request.getUserId()); // 프론트에서 받은 사용자 ID
+        parameters.put("pg_token", request.getPgToken()); // 프론트에서 받은 PG 토큰
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
+        return restTemplate.postForObject(
+                "https://open-api.kakaopay.com/online/v1/payment/approve",
+                requestEntity, KakaoApproveResponse.class);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,7 @@ logging:
         security: DEBUG
         web: DEBUG
         oauth2: DEBUG
+
+kakaopay :
+  secretKey : "DEV1E4CA68D7F1F8B36B8EEC8ADFEC88FDD4A324"
+  cid : "TC0ONETIME"


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #13 


## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 카카오페이 개발자센터 연결
- 카카오페이 결제 api 구현

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
공기계라서 카카오톡 설치 및 로그인이 어려워서 PC 큐알로 들어가 결제되는 방식으로 채택했습니다. 사진상 위 버전입니다.
![KakaoTalk_20250227_155455375](https://github.com/user-attachments/assets/01dee01e-be57-4129-9be5-85389a0960df)
